### PR TITLE
feat: implemented slingshot with cooldown system, progress bar and co…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.metallicgoat</groupId>
     <artifactId>Extra-Special-Items</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3</version>
 
     <repositories>
         <repository>

--- a/src/main/java/me/metallicgoat/specialItems/config/Config.java
+++ b/src/main/java/me/metallicgoat/specialItems/config/Config.java
@@ -4,9 +4,8 @@ import de.marcely.bedwars.tools.Helper;
 import de.marcely.bedwars.tools.Pair;
 import de.marcely.bedwars.tools.YamlConfigurationDescriptor;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
+
 import me.metallicgoat.specialItems.ExtraSpecialItemsPlugin;
 import me.metallicgoat.specialItems.utils.Console;
 import org.bukkit.Material;
@@ -86,6 +85,18 @@ public class Config {
     ConfigValue.ice_bridger_icon_material = parseItemStack(config.getString("Ice-Bridger.Icon-Type"), ConfigValue.ice_bridger_material);
     ConfigValue.ice_bridger_material = parseMaterial(config.getString("Ice-Bridger.Block-Type"), ConfigValue.ice_bridger_material);
     ConfigValue.ice_bridger_max_distance = config.getInt("Ice-Bridger.Max-Distance", ConfigValue.ice_bridger_max_distance);
+
+    // SLINGSHOT
+    ConfigValue.slingshot_icon_name = config.getString("Slingshot.Icon-Name");
+    ConfigValue.slingshot_icon_material = parseItemStack(config.getString("Slingshot.Icon-Type"), ConfigValue.slingshot_icon_material);
+    ConfigValue.slingshot_material = parseMaterial(config.getString("Slingshot.Icon-Type"), ConfigValue.slingshot_material);
+    ConfigValue.slingshot_force = config.getDouble("Slingshot.Force", ConfigValue.slingshot_force);
+    ConfigValue.slingshot_height_boost = config.getDouble("Slingshot.Height-Boost", ConfigValue.slingshot_height_boost);
+    ConfigValue.slingshot_max_y_boost = config.getDouble("Slingshot.Max-Y-Boost", ConfigValue.slingshot_max_y_boost);
+    ConfigValue.slingshot_cooldown_seconds = config.getInt("Slingshot.Cooldown-Seconds", ConfigValue.slingshot_cooldown_seconds);
+    ConfigValue.slingshot_cooldown_bars = config.getInt("Slingshot.Cooldown-Bars", ConfigValue.slingshot_cooldown_bars);
+    ConfigValue.slingshot_cooldown_message = config.getString("Slingshot.Cooldown-Message", ConfigValue.slingshot_cooldown_message);
+    ConfigValue.slingshot_use_sound = parseConfigSound(config, "Slingshot.Use-Sound", ConfigValue.slingshot_use_sound);
 
     // COMMAND ITEMS
     ConfigValue.command_item_enabled = config.getBoolean("Custom-Items.Enabled");
@@ -186,6 +197,18 @@ public class Config {
     config.set("Ice-Bridger.Block-Type", ConfigValue.ice_bridger_material.name());
     config.set("Ice-Bridger.Max-Distance", ConfigValue.ice_bridger_max_distance);
 
+    config.addEmptyLine();
+
+    config.addComment("Launch yourself with a SlingShot");
+    config.set("Slingshot.Icon-Name", ConfigValue.slingshot_icon_name);
+    config.set("Slingshot.Icon-Type", ConfigValue.slingshot_material.name());
+    config.set("Slingshot.Force", ConfigValue.slingshot_force);
+    config.set("Slingshot.Height-Boost", ConfigValue.slingshot_height_boost);
+    config.set("Slingshot.Max-Y-Boost", ConfigValue.slingshot_max_y_boost);
+    config.set("Slingshot.Cooldown-Seconds", ConfigValue.slingshot_cooldown_seconds);
+    config.set("Slingshot.Cooldown-Bars", ConfigValue.slingshot_cooldown_bars);
+    config.set("Slingshot.Cooldown-Message", ConfigValue.slingshot_cooldown_message);
+    config.set("Slingshot.Use-Sound", ConfigValue.slingshot_use_sound.toString());
     config.addEmptyLine();
 
     config.addComment("Create as many custom Special items at you want");

--- a/src/main/java/me/metallicgoat/specialItems/config/ConfigValue.java
+++ b/src/main/java/me/metallicgoat/specialItems/config/ConfigValue.java
@@ -49,6 +49,18 @@ public class ConfigValue {
   public static Material ice_bridger_material = Helper.get().getMaterialByName("ICE");
   public static int ice_bridger_max_distance = 37;
 
+  // SlingShot
+  public static String slingshot_icon_name = "SlingShot";
+  public static ItemStack slingshot_icon_material = Helper.get().parseItemStack("MAGMA_CREAM");
+  public static Material slingshot_material = Helper.get().getMaterialByName("MAGMA_CREAM");
+  public static double slingshot_force = 2.0;
+  public static double slingshot_height_boost = 0.5;
+  public static double slingshot_max_y_boost = 1.0;
+  public static int slingshot_cooldown_seconds = 7;
+  public static int slingshot_cooldown_bars = 20;
+  public static String slingshot_cooldown_message = "&7You are in cooldown for &e%seconds% &7seconds";
+  public static Sound slingshot_use_sound = Helper.get().getSoundByName("SLIME_WALK");
+
   // Command Item
   public static boolean command_item_enabled = false;
   public static HashMap<String, Pair<ItemStack, String>> command_item_player_commands = new HashMap<String, Pair<ItemStack, String>>() {{

--- a/src/main/java/me/metallicgoat/specialItems/customitems/CustomSpecialItem.java
+++ b/src/main/java/me/metallicgoat/specialItems/customitems/CustomSpecialItem.java
@@ -13,6 +13,7 @@ import me.metallicgoat.specialItems.customitems.handlers.CommandItemHandler;
 import me.metallicgoat.specialItems.customitems.handlers.EggBridgerHandler;
 import me.metallicgoat.specialItems.customitems.handlers.IceBridgerHandler;
 import me.metallicgoat.specialItems.customitems.handlers.SilverfishHandler;
+import me.metallicgoat.specialItems.customitems.handlers.SlingShotHandler;
 import me.metallicgoat.specialItems.customitems.handlers.TowerHandler;
 import me.metallicgoat.specialItems.utils.Console;
 import org.bukkit.inventory.ItemStack;
@@ -59,6 +60,12 @@ public class CustomSpecialItem {
         "silverfish",
         ConfigValue.silverfish_icon_name,
         ConfigValue.silverfish_icon_material));
+
+    register(new CustomSpecialItem(
+        SlingShotHandler::new,
+        "slingshot",
+        ConfigValue.slingshot_icon_name,
+        ConfigValue.slingshot_icon_material));
 
         /*
         register(new CustomSpecialItem(

--- a/src/main/java/me/metallicgoat/specialItems/customitems/handlers/SlingShotHandler.java
+++ b/src/main/java/me/metallicgoat/specialItems/customitems/handlers/SlingShotHandler.java
@@ -1,0 +1,149 @@
+package me.metallicgoat.specialItems.customitems.handlers;
+
+import de.marcely.bedwars.api.event.player.PlayerUseSpecialItemEvent;
+import de.marcely.bedwars.api.message.Message;
+import de.marcely.bedwars.tools.Helper;
+import de.marcely.bedwars.tools.NMSHelper;
+import me.metallicgoat.specialItems.config.ConfigValue;
+import me.metallicgoat.specialItems.customitems.CustomSpecialItemUseSession;
+import me.metallicgoat.specialItems.ExtraSpecialItemsPlugin;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class SlingShotHandler extends CustomSpecialItemUseSession {
+
+    private static final Map<UUID, Long> cooldowns = new HashMap<>();
+    private static final Map<UUID, BukkitTask> cooldownTasks = new HashMap<>();
+
+    public SlingShotHandler(PlayerUseSpecialItemEvent event) {
+        super(event);
+    }
+
+    @Override
+    public void run(PlayerUseSpecialItemEvent event) {
+        Player player = event.getPlayer();
+        UUID playerId = player.getUniqueId();
+
+        // Check if player is in cooldown
+        if (isInCooldown(playerId)) {
+            long remainingSeconds = getCooldownTimeLeft(playerId);
+            player.sendMessage(Message.build(ConfigValue.slingshot_cooldown_message.replace("%seconds%", String.valueOf(remainingSeconds))).done());
+            return;
+        }
+
+        this.takeItem();
+
+        // Apply launch velocity
+        Vector direction = player.getLocation().getDirection();
+        direction.multiply(ConfigValue.slingshot_force);
+        
+        // Limitar o boost vertical
+        double yBoost = direction.getY() + ConfigValue.slingshot_height_boost;
+        direction.setY(Math.min(yBoost, ConfigValue.slingshot_max_y_boost));
+        
+        player.setVelocity(direction);
+
+        // Set cooldown
+        setCooldown(playerId);
+
+        // Show cooldown in action bar
+        startCooldownTask(player);
+
+        // Play sound effect
+        Sound sound = ConfigValue.slingshot_use_sound;
+        if (sound != null)
+            player.playSound(player.getLocation(), sound, 1.0f, 1.0f);
+    }
+
+    private boolean isInCooldown(UUID playerId) {
+        if (!cooldowns.containsKey(playerId))
+            return false;
+
+        long cooldownEnd = cooldowns.get(playerId);
+        if (System.currentTimeMillis() >= cooldownEnd) {
+            cooldowns.remove(playerId);
+            return false;
+        }
+
+        return true;
+    }
+
+    private long getCooldownTimeLeft(UUID playerId) {
+        if (!cooldowns.containsKey(playerId))
+            return 0;
+
+        long cooldownEnd = cooldowns.get(playerId);
+        return (cooldownEnd - System.currentTimeMillis()) / 1000;
+    }
+
+    private void setCooldown(UUID playerId) {
+        cooldowns.put(playerId, System.currentTimeMillis() + (ConfigValue.slingshot_cooldown_seconds * 1000L));
+    }
+
+    private String formatCooldownBar(double secondsLeft) {
+        int filledBars = (int) Math.ceil((secondsLeft / ConfigValue.slingshot_cooldown_seconds) * ConfigValue.slingshot_cooldown_bars);
+        StringBuilder bar = new StringBuilder();
+
+        // Add filled bars in green
+        bar.append("§a");
+        for (int i = 0; i < filledBars; i++) {
+            bar.append("┇");
+        }
+
+        // Add empty bars in red
+        if (filledBars < ConfigValue.slingshot_cooldown_bars) {
+            bar.append("§c");
+            for (int i = filledBars; i < ConfigValue.slingshot_cooldown_bars; i++) {
+                bar.append("┇");
+            }
+        }
+
+        return bar.toString();
+    }
+
+    private void startCooldownTask(Player player) {
+        UUID playerId = player.getUniqueId();
+
+        // Cancel existing task if any
+        BukkitTask existingTask = cooldownTasks.get(playerId);
+        if (existingTask != null) {
+            existingTask.cancel();
+        }
+
+        BukkitTask task = new BukkitRunnable() {
+            double secondsLeft = ConfigValue.slingshot_cooldown_seconds;
+
+            @Override
+            public void run() {
+                if (secondsLeft <= 0 || !isInCooldown(playerId)) {
+                    NMSHelper.get().showActionbar(player, "");
+                    cooldowns.remove(playerId);
+                    cooldownTasks.remove(playerId);
+                    this.cancel();
+                    return;
+                }
+
+                String cooldownBar = formatCooldownBar(secondsLeft);
+                NMSHelper.get().showActionbar(player, Message.build("&f" + ConfigValue.slingshot_icon_name + " &r" + cooldownBar + " &f" + String.format("%.1f", secondsLeft).replace('.', ',') + "s").done());
+                secondsLeft -= 0.1;
+            }
+        }.runTaskTimer(ExtraSpecialItemsPlugin.getInstance(), 0L, 2L);
+
+        cooldownTasks.put(playerId, task);
+    }
+
+    @Override
+    protected void handleStop() {
+        // Cancel all cooldown tasks
+        cooldownTasks.values().forEach(BukkitTask::cancel);
+        cooldowns.clear();
+        cooldownTasks.clear();
+    }
+}


### PR DESCRIPTION
# Slingshot Special Item Implementation

## Overview
Added a new special item called Slingshot that allows players to launch themselves in their looking direction. The item features a cooldown system with visual feedback and fully configurable settings.

## Features
- **Launch Mechanics**
  - Players are launched in their looking direction
  - Configurable force and height boost
  - Smart vertical limit to prevent excessive height
  - Sound effect on launch

- **Cooldown System**
  - Visual progress bar in action bar
  - Decimal countdown timer (7.0s, 6.9s, etc.)
  - Color-coded progress (green for remaining time, red for elapsed)
  - Configurable cooldown duration and bar segments

- **Configuration Options**
```yaml
Slingshot:
  Icon-Name: 'Slingshot'
  Icon-Type: MAGMA_CREAM
  Force: 2.0
  Height-Boost: 0.5
  Max-Y-Boost: 1.0
  Cooldown-Seconds: 7
  Cooldown-Bars: 20
  Cooldown-Message: '&7You are in cooldown for &e%seconds% &7seconds'
  Use-Sound: IRONGOLEM_THROW
 ```
- **Technical Details**
  - Compatible with Minecraft 1.8
  - Uses efficient task scheduling for cooldown
  - Memory-efficient UUID-based cooldown tracking
  - Proper cleanup on plugin disable/reload
  - NMS integration for action bar messages