### PR TITLE
fix: update slingshot icon message to action bar cooldown message on Actionbar

### DIFF
--- a/src/main/java/me/metallicgoat/specialItems/customitems/handlers/SlingShotHandler.java
+++ b/src/main/java/me/metallicgoat/specialItems/customitems/handlers/SlingShotHandler.java
@@ -128,7 +128,7 @@ public class SlingShotHandler extends CustomSpecialItemUseSession {
         final String seconds = ConfigValue.slingshot_cooldown_seconds_format.format(secondsLeft);
 
         NMSHelper.get().showActionbar(player,
-            Message.build(ConfigValue.slingshot_icon_name)
+            Message.build(ConfigValue.slingshot_action_bar)
                 .placeholder("cooldown-bar", cooldownBar)
                 .placeholder("seconds", seconds)
                 .placeholder("item-name", ConfigValue.slingshot_icon_name)


### PR DESCRIPTION
This pull request fixes an issue where the Message.build method was using the incorrect configuration value ConfigValue.slingshot_icon_name. The reference has been updated to ConfigValue.slingshot_action_bar to ensure the correct message is displayed in the action bar.